### PR TITLE
bump leaflet, esri leaflet and geocoder versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .DS_Store
+bundle.js
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 Example of using [Esri Leaflet](http://esri.github.io/esri-leaflet) with [WebPack](http://webpack.github.io/)!
 
-1. Install JSPM `npm install -g webpack`
-2. Install a local web server `npm install -g http-server`
-2. [Fork and clone this repo](https://help.github.com/articles/fork-a-repo)
-3. `cd` into `esri-leaflet-webpack-example`
-4. Install dependencies with `npm install`
-5. Build the project with `webpack`
-6. Start the web server `http-server .`
-7. Open [http://localhost:8080](http://localhost:8080) in your browser.
+1. [Fork and clone this repo](https://help.github.com/articles/fork-a-repo)
+2. `cd` into `esri-leaflet-webpack-example`
+3. Install dependencies with `npm install`
+4. start the live development server with `npm start`
+5. Open http://localhost:8080/webpack-dev-server/ in your browser.
 
 ## Smaller Builds Using the Esri Leaflet Bundler
 
@@ -49,7 +46,7 @@ export default {
 };
 ```
 
-Note that since will will compile this to ES 6 modules we can export not just the `default` export but exports for each individual module.
+Note that since will will compile this to ES6 modules we can export not just the `default` export but exports for each individual module.
 
 Then run `esri-leaflet-bundler esri-leaflet-custom-build.js -o esri-leaflet-custom.js --sourcemap inline --format cjs` to generate your custom build.
 

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Browserify Example</title>
+    <title>Webpack Example</title>
   </head>
   <link rel="stylesheet" href="node_modules/leaflet/dist/leaflet.css" />
   <link rel="stylesheet" href="node_modules/esri-leaflet-geocoder/dist/esri-leaflet-geocoder.css" />

--- a/main.js
+++ b/main.js
@@ -21,7 +21,7 @@ var geocoding = require('esri-leaflet-geocoder');
 
 // since leaflet is bundled into the browserify package it won't be able to detect where the images
 // solution is to point it to where you host the the leaflet images yourself
-L.Icon.Default.imagePath = 'http://cdn.leafletjs.com/leaflet-0.7.3/images';
+L.Icon.Default.imagePath = 'https://unpkg.com/leaflet@1.0.1/dist/images/';
 
 // create map
 var map = L.map('map').setView([51.505, -0.09], 13);
@@ -31,7 +31,7 @@ esri.basemapLayer('Topographic').addTo(map);
 
 // add layer
 esri.featureLayer({
-  url: '//services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/gisday/FeatureServer/0/'
+  url: 'https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/gisday/FeatureServer/0/'
 }).addTo(map);
 
 // add search control
@@ -39,7 +39,7 @@ geocoding.geosearch({
   providers: [
     geocoding.arcgisOnlineProvider(),
     geocoding.featureLayerProvider({
-      url: '//services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/gisday/FeatureServer/0/',
+      url: 'https://services.arcgis.com/uCXeTVveQzP4IIcx/arcgis/rest/services/gisday/FeatureServer/0/',
       searchFields: ['Name', 'Organization'],
       label: 'GIS Day Events',
       bufferRadius: 20000,

--- a/package.json
+++ b/package.json
@@ -1,21 +1,28 @@
 {
   "name": "esri-leaflet-webpack-example",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "webpack.config.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "webpack-dev-server --progress --colors",
+    "build": "webpack"
   },
-  "author": "",
+  "author": "Patrick Arlt",
   "license": "Apache-2.0",
   "dependencies": {
-    "esri-leaflet": "^2.0.0-beta.5",
-    "esri-leaflet-geocoder": "^2.0.0-beta.3",
-    "leaflet": "^1.0.0-beta.1"
+    "esri-leaflet": "^2.0.4",
+    "esri-leaflet-geocoder": "2.1.4",
+    "leaflet": "^1.0.0"
   },
   "devDependencies": {
-    "babel-core": "^5.8.3",
-    "babel-loader": "^5.3.2",
-    "webpack": "^1.10.4"
+    "babel-core": "^6.17.0",
+    "babel-loader": "^6.2.5",
+    "webpack": "^1.13.2",
+    "webpack-dev-server": "^1.16.2"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Esri/esri-leaflet-webpack-example.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "author": "Patrick Arlt",
   "license": "Apache-2.0",
   "dependencies": {
-    "esri-leaflet": "^2.0.4",
-    "esri-leaflet-geocoder": "2.1.4",
+    "esri-leaflet": "^2.0.0",
+    "esri-leaflet-geocoder": "^2.0.0",
     "leaflet": "^1.0.0"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ module.exports = {
     entry: './main.js',
     output: {
         path: __dirname,
-        filename: 'bundle.js',
+        filename: 'bundle.js'
     },
     module: {
         loaders: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,14 +2,10 @@ module.exports = {
     entry: './main.js',
     output: {
         path: __dirname,
-        filename: 'bundle.js'
+        filename: 'bundle.js',
     },
     module: {
         loaders: [
-            {
-              test: /node_modules\/esri-leaflet/,
-              loader: 'babel-loader?whitelist[]=es6.modules&loose[]=es6.modules'
-            },
             {
               test: /node_modules\/esri-leaflet-geocoder/,
               loader: 'babel-loader?whitelist[]=es6.modules&loose[]=es6.modules'
@@ -17,3 +13,4 @@ module.exports = {
         ]
     }
 };
+


### PR DESCRIPTION
~~my original goal was to figure out how to ditch the babel loader (as per [release notes](https://github.com/Esri/esri-leaflet/releases/tag/v2.0.0-beta.8)) but i couldn't figure it out.~~
- bumped leaflet to 1.x
- bumped esri leaflet to 2.x
- added `npm start` to launch a live development server that watches source for changes

i haven't figured out why yet, but esri-leaflet-geocoder still requires the babel loader.
